### PR TITLE
refactor: rename project name to everycodeacademy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# PostgreSQL
+POSTGRES_DB=everycodeacademy
+POSTGRES_USER=everybody
+POSTGRES_PASSWORD=change-me
+
+# Backend datasource
+SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/everycodeacademy
+SPRING_DATASOURCE_USERNAME=everybody
+SPRING_DATASOURCE_PASSWORD=change-me
+
+# Optional
+TZ=Asia/Seoul

--- a/.github/workflows/initial-monorepo-ci.yml
+++ b/.github/workflows/initial-monorepo-ci.yml
@@ -1,0 +1,41 @@
+name: Initial Monorepo CI
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/initial-monorepo-ci.yml'
+  push:
+    branches: [ main ]
+
+jobs:
+  backend-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Test backend
+        run: gradle test --no-daemon
+
+  frontend-static-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate frontend static files
+        run: |
+          test -f frontend/index.html
+          test -f frontend/src/app.jsx
+          test -f frontend/src/styles.css
+          rg -n "unpkg.com/react@18" frontend/index.html
+          rg -n "ReactDOM.createRoot" frontend/src/app.jsx

--- a/.github/workflows/initial-monorepo-ci.yml
+++ b/.github/workflows/initial-monorepo-ci.yml
@@ -37,5 +37,5 @@ jobs:
           test -f frontend/index.html
           test -f frontend/src/app.jsx
           test -f frontend/src/styles.css
-          rg -n "unpkg.com/react@18" frontend/index.html
-          rg -n "ReactDOM.createRoot" frontend/src/app.jsx
+          grep -n "unpkg.com/react@18" frontend/index.html
+          grep -n "ReactDOM.createRoot" frontend/src/app.jsx

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+backend/.gradle/
+.env
+*.env.local

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# EveryCodeAcademy - Initial Monorepo Setup
+
+요청하신 구조에 맞춰 **frontend / backend 2개 프로젝트**로 초기 셋팅한 상태입니다.
+
+## 프로젝트 구조
+
+```text
+.
+├─ backend/   # Spring Boot 3.x (Java 17)
+├─ frontend/  # React(정적 페이지)
+└─ docker-compose.yml  # postgres/backend/frontend 통합 기동
+```
+
+## Backend
+- Spring Boot `3.5.0`
+- 기본 엔드포인트: `GET /api/health`
+- DB: PostgreSQL 16 연결 설정 (`application.yml`에서 환경변수 기반)
+- Dockerfile 포함
+
+## Frontend
+- **Vite 없이 React만 사용**하는 정적 앱 구성
+- `index.html`에서 React/ReactDOM CDN 로드
+- 초기 랜딩 화면/핵심 기능 섹션 추가
+- nginx 기반 Dockerfile 포함
+
+## 보안 관련 설정
+- 비밀번호/시크릿은 레포에 하드코딩하지 않고, `.env` 파일로 주입합니다.
+- `.env.example`을 복사해 `.env`를 생성한 뒤 값을 바꿔 사용하세요.
+
+```bash
+cp .env.example .env
+# .env 내 change-me 값을 실제 값으로 변경
+```
+
+## Docker 실행
+```bash
+docker compose up --build
+```
+
+- Frontend: http://localhost:5173
+- Backend: http://localhost:8080/api/health
+- PostgreSQL: localhost:5432
+
+## CI 스캐폴딩
+- `.github/workflows/initial-monorepo-ci.yml` 추가
+  - backend: gradle test
+  - frontend: 정적 파일/React CDN 참조 검증
+
+> 현재 환경에서 외부 레지스트리 접근 제한이 있으면 CI/로컬 설치가 실패할 수 있습니다.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+
+FROM gradle:8.8-jdk17 AS build
+WORKDIR /app
+COPY . .
+RUN gradle clean bootJar --no-daemon
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     runtimeOnly("org.postgresql:postgresql")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("com.h2database:h2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+    java
+    id("org.springframework.boot") version "3.5.0"
+    id("io.spring.dependency-management") version "1.1.7"
+}
+
+group = "com.everycodeacademy"
+version = "0.0.1-SNAPSHOT"
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    runtimeOnly("org.postgresql:postgresql")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "backend"

--- a/backend/settings.gradle.kts
+++ b/backend/settings.gradle.kts
@@ -1,1 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = "backend"

--- a/backend/src/main/java/com/everycodeacademy/backend/BackendApplication.java
+++ b/backend/src/main/java/com/everycodeacademy/backend/BackendApplication.java
@@ -1,0 +1,12 @@
+package com.everycodeacademy.backend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/everycodeacademy/backend/controller/HealthController.java
+++ b/backend/src/main/java/com/everycodeacademy/backend/controller/HealthController.java
@@ -1,0 +1,21 @@
+package com.everycodeacademy.backend.controller;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class HealthController {
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        return Map.of(
+            "service", "everycodeacademy-backend",
+            "status", "UP",
+            "timestamp", OffsetDateTime.now().toString()
+        );
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+spring:
+  application:
+    name: everycodeacademy-backend
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/everycodeacademy}
+    username: ${SPRING_DATASOURCE_USERNAME:everybody}
+    password: ${SPRING_DATASOURCE_PASSWORD:}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+  jackson:
+    time-zone: Asia/Seoul
+
+server:
+  port: ${SERVER_PORT:8080}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info

--- a/backend/src/test/java/com/everycodeacademy/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/everycodeacademy/backend/BackendApplicationTests.java
@@ -2,8 +2,10 @@ package com.everycodeacademy.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BackendApplicationTests {
 
     @Test

--- a/backend/src/test/java/com/everycodeacademy/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/everycodeacademy/backend/BackendApplicationTests.java
@@ -1,0 +1,12 @@
+package com.everycodeacademy.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BackendApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:everycodeacademy;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,43 @@
-version: '3.8'
+version: '3.9'
 
 services:
-  db:
-    image: mysql:8.4
-    container_name: mysql-db
+  postgres:
+    image: postgres:16
+    container_name: everycodeacademy-postgres
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: kyjtester
-      MYSQL_DATABASE: everycodeacademy
-      MYSQL_USER: kyjtester1
-      MYSQL_PASSWORD: test4321
+      POSTGRES_DB: ${POSTGRES_DB:-everycodeacademy}
+      POSTGRES_USER: ${POSTGRES_USER:-everybody}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      TZ: ${TZ:-Asia/Seoul}
     ports:
-      - "3306:3306"                        # 호스트:컨테이너 포트 매핑
+      - "5432:5432"
     volumes:
-      - db_data:/var/lib/mysql             # 데이터 영속성을 위한 볼륨
+      - postgres_data:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ./backend
+    container_name: everycodeacademy-backend
+    restart: unless-stopped
+    environment:
+      SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL:-jdbc:postgresql://postgres:5432/everycodeacademy}
+      SPRING_DATASOURCE_USERNAME: ${SPRING_DATASOURCE_USERNAME:-everybody}
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD:?SPRING_DATASOURCE_PASSWORD is required}
+    depends_on:
+      - postgres
+    ports:
+      - "8080:8080"
+
+  frontend:
+    build:
+      context: ./frontend
+    container_name: everycodeacademy-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "5173:80"
 
 volumes:
-  db_data:
+  postgres_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+
+FROM nginx:1.27-alpine
+WORKDIR /usr/share/nginx/html
+COPY . .
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>everycodeacademy</title>
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel" data-presets="react" src="/src/app.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -1,0 +1,31 @@
+const coreFeatures = [
+  '코딩 테스트 필수 개념 정리',
+  '문제 풀이 리뷰와 코드 리뷰 공유',
+  '커뮤니티 기반 댓글/좋아요 소통'
+];
+
+function App() {
+  return (
+    <main className="container">
+      <h1>everycodeacademy</h1>
+      <p>코딩 테스트 학습과 코드 리뷰를 위한 커뮤니티 플랫폼 초기 화면입니다.</p>
+
+      <section>
+        <h2>핵심 기능(초기 스코프)</h2>
+        <ul>
+          {coreFeatures.map((feature) => (
+            <li key={feature}>{feature}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="api-status">
+        <h2>백엔드 연동 경로</h2>
+        <code>GET /api/health</code>
+      </section>
+    </main>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,30 @@
+:root {
+  font-family: "Pretendard", "Noto Sans KR", system-ui, sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+}
+
+.container {
+  max-width: 760px;
+  margin: 4rem auto;
+  padding: 2rem;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+h1 {
+  margin-top: 0;
+  color: #1d4ed8;
+}
+
+.api-status {
+  margin-top: 2rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: #eff6ff;
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,6 @@ pluginManagement {
     }
 }
 
-rootProject.name = "everybodycodeacademy"
+rootProject.name = "everycodeacademy"
 
 include("user-service","content-service","community-service","code-review-service","common","database")


### PR DESCRIPTION
### Motivation
- 프로젝트 식별자를 요청에 따라 전반적으로 `everycodeacademy`로 통일하기 위해 변경했습니다.
- 백엔드 서비스명, Java 패키지, Docker 리소스, 환경변수 기본값 및 프론트엔드 UI의 표시명을 일관되게 맞추기 위함입니다.

### Description
- 루트 Gradle 프로젝트명을 `settings.gradle.kts`에서 `everycodeacademy`로 변경하고 백엔드 `group`을 `com.everycodeacademy`로 업데이트했습니다.
- `docker-compose.yml`을 MySQL에서 PostgreSQL 설정으로 전환하고 컨테이너명/DB 기본값/백엔드 datasource 기본 URL을 `everycodeacademy` 기반으로 수정했습니다.
- Java 패키지 경로를 `com.everybodycodeacademy`에서 `com.everycodeacademy`로 리네임(메인 및 테스트 모두)하고 `BackendApplication`, `HealthController`, 테스트 파일을 해당 패키지로 갱신했습니다.
- `backend/src/main/resources/application.yml`, `.env.example`, 프론트엔드 `frontend/index.html` 및 `frontend/src/app.jsx`, `README.md`, `.gitignore`를 새 프로젝트명 기준으로 업데이트했습니다.
- 프론트/백엔드 Dockerfile과 초기 GitHub Actions CI (`.github/workflows/initial-monorepo-ci.yml`) 스켈레톤을 추가했습니다.

### Testing
- 자동화 정적 검증으로 `git diff --check`를 실행했고 문제 없이 통과했습니다.
- 레포 전역에서 `rg`로 이전 식별자(예: `everybodycodeacademy`)를 검색해 잔존 여부를 확인했으며 검색된 항목이 남아있지 않은 것을 확인했습니다.
- `cd frontend && python -m http.server 5173`로 정적 서버를 띄운 뒤 Playwright로 `http://127.0.0.1:5173` 스크린샷을 캡처해 프론트엔드 로드 확인을 완료했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c37bac86c8326946bb5048ea6d45d)